### PR TITLE
Fix recaptcha expiration error message issue

### DIFF
--- a/src/components/contact/ContactForm/index.jsx
+++ b/src/components/contact/ContactForm/index.jsx
@@ -121,7 +121,12 @@ const ContactForm = ({ errors, touched, setFieldValue, isSubmitting }) => {
               component={Recaptcha}
               sitekey="6Lcs6lQUAAAAAEwhNH2IsobIe2csdda4TU3efpMN"
               name="recaptcha"
-              onChange={value => setFieldValue('recaptcha', value)}
+              onChange={value => {
+                if (!value) {
+                  value = "";
+                }
+                setFieldValue('recaptcha', value)
+              }}
             />
             <ErrorMessage component={Error} name="recaptcha" />
             <Center>


### PR DESCRIPTION
When Google reCAPTCHA value expires a error is shown which is not generic to end-user but more suitable to developer. This fix makes that error message(string) generic to end-user like for e.g. "reCAPTCHA value is required"